### PR TITLE
Tab/single user

### DIFF
--- a/periph_sw/nRF52_RGB_Strip/eeprom_handler.h
+++ b/periph_sw/nRF52_RGB_Strip/eeprom_handler.h
@@ -28,8 +28,8 @@ class Settings
     {
         num_pixels = 50;
         device_name = "MyFahrrad";
-        sig_front_lower = 1;
-        sig_rear_upper = num_pixels;
+        sig_front_lower = 0;
+        sig_rear_upper = num_pixels - 1;
         sig_front_upper = int(num_pixels/4) - sig_front_lower;
         sig_rear_lower = sig_rear_upper - int(num_pixels/4);
     }

--- a/periph_sw/nRF52_RGB_Strip/eeprom_handler.h
+++ b/periph_sw/nRF52_RGB_Strip/eeprom_handler.h
@@ -42,10 +42,14 @@ class EEPROM_Handler
     {
     }
 
-    void static load(Settings &settings)
+    void configure(void)
     {
         // Initialize Nffs
         Nffs.begin();
+    }
+
+    void static load(Settings &settings)
+    {
         NffsFile file;
         file.open(FILENAME, FS_ACCESS_READ);
 
@@ -75,7 +79,6 @@ class EEPROM_Handler
 
     void static save(Settings &settings)
     {
-        Nffs.begin();
         NffsFile file;
         
         Serial.println("Open " FILENAME " file to write ... ");
@@ -84,11 +87,11 @@ class EEPROM_Handler
         {
             file.seek(0);
             write_setting(file, "num_pixels", String(settings.num_pixels));
-            write_setting(file, "device_name", settings.device_name);
-            write_setting(file, "sig_front_lower", String(settings.sig_front_lower));
-            write_setting(file, "sig_front_upper", String(settings.sig_front_upper));
-            write_setting(file, "sig_rear_lower", String(settings.sig_rear_lower));
-            write_setting(file, "sig_rear_upper", String(settings.sig_rear_upper));
+            write_setting(file, "d_name", settings.device_name);
+            write_setting(file, "sig_fl", String(settings.sig_front_lower));
+            write_setting(file, "sig_fu", String(settings.sig_front_upper));
+            write_setting(file, "sig_rl", String(settings.sig_rear_lower));
+            write_setting(file, "sig_ru", String(settings.sig_rear_upper));
             file.close();
         }
         else
@@ -139,23 +142,23 @@ class EEPROM_Handler
             {
                 settings.num_pixels = setting_val.toInt();
             }
-            else if (setting_name == "device_name")
+            else if (setting_name == "d_name")
             {
                 settings.device_name = setting_val;
             }
-            else if (setting_name == "sig_front_lower")
+            else if (setting_name == "sig_fl")
             {
                 settings.sig_front_lower = setting_val.toInt();
             }
-            else if (setting_name == "sig_front_upper")
+            else if (setting_name == "sig_fu")
             {
                 settings.sig_front_upper = setting_val.toInt();
             }
-            else if (setting_name == "sig_rear_lower")
+            else if (setting_name == "sig_rl")
             {
                 settings.sig_rear_lower = setting_val.toInt();
             }
-            else if (setting_name == "sig_rear_upper")
+            else if (setting_name == "sig_ru")
             {
                 settings.sig_rear_upper = setting_val.toInt();
             }

--- a/periph_sw/nRF52_RGB_Strip/eeprom_handler.h
+++ b/periph_sw/nRF52_RGB_Strip/eeprom_handler.h
@@ -14,10 +14,11 @@ class Settings
   public:
     unsigned int num_pixels;
     String device_name;
-    unsigned int sig_front_lower;
-    unsigned int sig_front_upper;
-    unsigned int sig_rear_lower;
-    unsigned int sig_rear_upper;
+    // TrafficMode indices, [1; num_pixels].
+    unsigned int traffic_front_lower;
+    unsigned int traffic_front_upper;
+    unsigned int traffic_rear_lower;
+    unsigned int traffic_rear_upper;
 
     Settings()
     {
@@ -28,10 +29,10 @@ class Settings
     {
         num_pixels = 50;
         device_name = "MyFahrrad";
-        sig_front_lower = 0;
-        sig_rear_upper = num_pixels - 1;
-        sig_front_upper = int(num_pixels/4) - sig_front_lower;
-        sig_rear_lower = sig_rear_upper - int(num_pixels/4);
+        traffic_front_lower = 1;
+        traffic_rear_upper = num_pixels;
+        traffic_front_upper = int(num_pixels/4) - traffic_front_lower;
+        traffic_rear_lower = traffic_rear_upper - int(num_pixels/4);
     }
 };
 
@@ -88,10 +89,10 @@ class EEPROM_Handler
             file.seek(0);
             write_setting(file, "num_pixels", String(settings.num_pixels));
             write_setting(file, "d_name", settings.device_name);
-            write_setting(file, "sig_fl", String(settings.sig_front_lower));
-            write_setting(file, "sig_fu", String(settings.sig_front_upper));
-            write_setting(file, "sig_rl", String(settings.sig_rear_lower));
-            write_setting(file, "sig_ru", String(settings.sig_rear_upper));
+            write_setting(file, "traffic_fl", String(settings.traffic_front_lower));
+            write_setting(file, "traffic_fu", String(settings.traffic_front_upper));
+            write_setting(file, "traffic_rl", String(settings.traffic_rear_lower));
+            write_setting(file, "traffic_ru", String(settings.traffic_rear_upper));
             file.close();
         }
         else
@@ -146,21 +147,21 @@ class EEPROM_Handler
             {
                 settings.device_name = setting_val;
             }
-            else if (setting_name == "sig_fl")
+            else if (setting_name == "traffic_fl")
             {
-                settings.sig_front_lower = setting_val.toInt();
+                settings.traffic_front_lower = setting_val.toInt();
             }
-            else if (setting_name == "sig_fu")
+            else if (setting_name == "traffic_fu")
             {
-                settings.sig_front_upper = setting_val.toInt();
+                settings.traffic_front_upper = setting_val.toInt();
             }
-            else if (setting_name == "sig_rl")
+            else if (setting_name == "traffic_rl")
             {
-                settings.sig_rear_lower = setting_val.toInt();
+                settings.traffic_rear_lower = setting_val.toInt();
             }
-            else if (setting_name == "sig_ru")
+            else if (setting_name == "traffic_ru")
             {
-                settings.sig_rear_upper = setting_val.toInt();
+                settings.traffic_rear_upper = setting_val.toInt();
             }
             else
             {

--- a/periph_sw/nRF52_RGB_Strip/eeprom_handler.h
+++ b/periph_sw/nRF52_RGB_Strip/eeprom_handler.h
@@ -14,6 +14,10 @@ class Settings
   public:
     unsigned int num_pixels;
     String device_name;
+    unsigned int sig_front_lower;
+    unsigned int sig_front_upper;
+    unsigned int sig_rear_lower;
+    unsigned int sig_rear_upper;
 
     Settings()
     {
@@ -24,6 +28,10 @@ class Settings
     {
         num_pixels = 50;
         device_name = "MyFahrrad";
+        sig_front_lower = 1;
+        sig_rear_upper = num_pixels;
+        sig_front_upper = int(num_pixels/4) - sig_front_lower;
+        sig_rear_lower = sig_rear_upper - int(num_pixels/4);
     }
 };
 
@@ -77,6 +85,10 @@ class EEPROM_Handler
             file.seek(0);
             write_setting(file, "num_pixels", String(settings.num_pixels));
             write_setting(file, "device_name", settings.device_name);
+            write_setting(file, "sig_front_lower", String(settings.sig_front_lower));
+            write_setting(file, "sig_front_upper", String(settings.sig_front_upper));
+            write_setting(file, "sig_rear_lower", String(settings.sig_rear_lower));
+            write_setting(file, "sig_rear_upper", String(settings.sig_rear_upper));
             file.close();
         }
         else
@@ -130,6 +142,22 @@ class EEPROM_Handler
             else if (setting_name == "device_name")
             {
                 settings.device_name = setting_val;
+            }
+            else if (setting_name == "sig_front_lower")
+            {
+                settings.sig_front_lower = setting_val.toInt();
+            }
+            else if (setting_name == "sig_front_upper")
+            {
+                settings.sig_front_upper = setting_val.toInt();
+            }
+            else if (setting_name == "sig_rear_lower")
+            {
+                settings.sig_rear_lower = setting_val.toInt();
+            }
+            else if (setting_name == "sig_rear_upper")
+            {
+                settings.sig_rear_upper = setting_val.toInt();
             }
             else
             {

--- a/periph_sw/nRF52_RGB_Strip/led_lib.h
+++ b/periph_sw/nRF52_RGB_Strip/led_lib.h
@@ -223,16 +223,14 @@ class CtrlLED
         this->setPixelsOff(); // Init: switch evertyhing off.
 
         // Front.
-        for (int i = this->p_settings->sig_front_lower; i < this->p_settings->sig_front_upper; ++i)
+        for (int i = std::max(this->p_settings->traffic_front_lower - 1, 0U); i < this->p_settings->traffic_front_upper; ++i)
         {
             strip.setPixelColor(i, strip.Color(255, 255, 255));
-            Serial.println(i);
         }
         // Rear.
-        for (int i = this->p_settings->sig_rear_lower; i < this->p_settings->sig_rear_upper; ++i)
+        for (int i = std::max(this->p_settings->traffic_rear_lower - 1, 0U); i < this->p_settings->traffic_rear_upper; ++i)
         {
             strip.setPixelColor(i, strip.Color(255, 0, 0));
-            Serial.println(i);
         }
         
         strip.show();

--- a/periph_sw/nRF52_RGB_Strip/led_lib.h
+++ b/periph_sw/nRF52_RGB_Strip/led_lib.h
@@ -1,14 +1,19 @@
 #ifndef LED_H
 #define LED_H
 
+#define __ASSERT_USE_STDERR
+
+#include <assert.h>
 #include <Adafruit_NeoPixel.h>
+
+#include "eeprom_handler.h"
 
 class CtrlLED
 {
   public:
     int pinDebug;
     int pinData;
-    int numpixels;
+    const Settings * p_settings;
 
     int valRed;
     int valGreen;
@@ -19,11 +24,13 @@ class CtrlLED
 
     Adafruit_NeoPixel strip;
 
-    CtrlLED(int pinData, int pinDebug)
+    CtrlLED(int pinData, int pinDebug, Settings const * const p_settings)
     {
+        assert(NULL != p_settings);
+
         this->pinDebug = pinDebug;
         this->pinData = pinData;
-        this->numpixels = 1;
+        this->p_settings = p_settings;
 
         // declare the ledPin as an OUTPUT:
         pinMode(pinData, OUTPUT);
@@ -36,13 +43,12 @@ class CtrlLED
         strip.begin(); // This initializes the NeoPixel library.
     }
 
-    void configure(unsigned int numpixels)
+    void configure(void)
     {
         setRGB(255, 255, 255);
         neoPixelType pixelType = NEO_GRB + NEO_KHZ800;
 
-        this->numpixels = numpixels;
-        strip.updateLength(numpixels);
+        strip.updateLength(this->p_settings->num_pixels);
         strip.updateType(pixelType);
         strip.setPin(this->pinData);
     }
@@ -135,13 +141,13 @@ class CtrlLED
     /* Dimmed multi chase. */
     void dimmedMultiChase(unsigned int nbChases = 2, unsigned int trainLength = 5)
     {
-        // Minimum parameter values.
-        nbChases = max(1, nbChases);
-        trainLength = max(1, trainLength);
+        // Constraint parameters.
+        nbChases = constrain(nbChases, 1, this->p_settings->num_pixels);
+        trainLength = constrain(trainLength, 1, this->p_settings->num_pixels);
 
         // Compute useful info.
-        int offset = ((global_millis() % (int)period_ms) / (float)period_ms) * numpixels;
-        int gapBetweenChases = (this->numpixels / nbChases);
+        int offset = ((global_millis() % (int)period_ms) / (float)period_ms) * this->p_settings->num_pixels;
+        int gapBetweenChases = (this->p_settings->num_pixels / nbChases);
         int intensityStep = 0xFF / trainLength;
 
         this->setPixelsOff(); // Init: switch evertyhing off.
@@ -149,11 +155,11 @@ class CtrlLED
         for (int chaseIdx = 0; chaseIdx < nbChases; ++chaseIdx)
         {
             // Get first chase
-            int leaderIdx = (offset + (chaseIdx * gapBetweenChases)) % this->numpixels;
+            int leaderIdx = (offset + (chaseIdx * gapBetweenChases)) % this->p_settings->num_pixels;
             // Switch on the leds.
             for (int followerIdx = 1; followerIdx < (trainLength + 1); ++followerIdx)
             {
-                int ledIdx = (leaderIdx + followerIdx) % this->numpixels;
+                int ledIdx = (leaderIdx + followerIdx) % this->p_settings->num_pixels;
                 int ledIntensity = intensityStep * followerIdx;
                 strip.setPixelColor(ledIdx, rgbiToColor(valRed, valGreen, valBlue, ledIntensity));
             }
@@ -164,8 +170,8 @@ class CtrlLED
 
     void pileUp()
     {
-        int offset = ((global_millis() % (int)period_ms) / (float)period_ms) * (numpixels);
-        for (int i = 0; i < numpixels; i++)
+        int offset = ((global_millis() % (int)period_ms) / (float)period_ms) * (this->p_settings->num_pixels);
+        for (int i = 0; i < this->p_settings->num_pixels; i++)
         {
             int intensity = 0;
             if (i <= offset)
@@ -181,21 +187,21 @@ class CtrlLED
     void modeRainbow(void)
     {
         // Determine parameters according to the number of configured leds and colors.
-        unsigned int nbChases = max(1, this->NB_PRESET_COLORS);
-        unsigned int trainLength = max(1, this->numpixels / nbChases);
-        unsigned int offset = ((global_millis() % (int)period_ms) / (float)period_ms) * numpixels;
+        unsigned int nbChases = constrain(this->NB_PRESET_COLORS, 1, this->p_settings->num_pixels);
+        unsigned int trainLength = constrain(this->p_settings->num_pixels / nbChases, 1, this->p_settings->num_pixels);
+        unsigned int offset = ((global_millis() % (int)period_ms) / (float)period_ms) * this->p_settings->num_pixels;
 
         /* Two partitions have to be distinguished.
-        * Chases might have different trainLength due to a non-null rest of the divison numpixels/nbChases.
+        * Chases might have different trainLength due to a non-null rest of the divison this->p_settings->num_pixels/nbChases.
         * The left-hand-side of the partition will have a (trainLength + 1) length to use the pixels left. */
-        unsigned int partitionIdx = floor(this->numpixels / nbChases);
+        unsigned int partitionIdx = floor(this->p_settings->num_pixels / nbChases);
 
         this->setPixelsOff(); // Init: switch evertyhing off.
 
         for (int chaseIdx = 0; chaseIdx < nbChases; ++chaseIdx)
         {
             Color rgb = this->presetColors[chaseIdx];
-            int leaderIdx = (offset + (chaseIdx * trainLength)) % this->numpixels; // Chase start.
+            int leaderIdx = (offset + (chaseIdx * trainLength)) % this->p_settings->num_pixels; // Chase start.
             unsigned int lastIdx = leaderIdx + trainLength;
             if (chaseIdx < partitionIdx) {
                 lastIdx += 1;
@@ -204,7 +210,7 @@ class CtrlLED
             // Switch on the leds.
             for (int i = leaderIdx; i < lastIdx; ++i)
             {
-                int ledIdx = i % this->numpixels;
+                int ledIdx = i % this->p_settings->num_pixels;
                 strip.setPixelColor(ledIdx, rgbiToColor(rgb.r, rgb.g, rgb.b, 0xFF));
             }
         }
@@ -254,7 +260,7 @@ class CtrlLED
 
     void writeEach(uint32_t color)
     {
-        for (int i = 0; i < numpixels; i++)
+        for (int i = 0; i < this->p_settings->num_pixels; i++)
         {
             strip.setPixelColor(i, color);
         }
@@ -272,7 +278,7 @@ class CtrlLED
     // Set all pixels off. Not calling show.
     void setPixelsOff(void)
     {
-        for (unsigned int i = 0; i < numpixels; ++i)
+        for (unsigned int i = 0; i < this->p_settings->num_pixels; ++i)
         {
             strip.setPixelColor(i, strip.Color(0, 0, 0));
         }

--- a/periph_sw/nRF52_RGB_Strip/led_lib.h
+++ b/periph_sw/nRF52_RGB_Strip/led_lib.h
@@ -218,6 +218,26 @@ class CtrlLED
         strip.show();
     }
 
+    void modeTraffic(void)
+    {
+        this->setPixelsOff(); // Init: switch evertyhing off.
+
+        // Front.
+        for (int i = this->p_settings->sig_front_lower; i < this->p_settings->sig_front_upper; ++i)
+        {
+            strip.setPixelColor(i, strip.Color(255, 255, 255));
+            Serial.println(i);
+        }
+        // Rear.
+        for (int i = this->p_settings->sig_rear_lower; i < this->p_settings->sig_rear_upper; ++i)
+        {
+            strip.setPixelColor(i, strip.Color(255, 0, 0));
+            Serial.println(i);
+        }
+        
+        strip.show();
+    }
+
     void setTimeOffset(int utc_millis)
     {
         time_offset = utc_millis - millis();

--- a/periph_sw/nRF52_RGB_Strip/nRF52_RGB_Strip.ino
+++ b/periph_sw/nRF52_RGB_Strip/nRF52_RGB_Strip.ino
@@ -17,7 +17,8 @@ enum LEDMode
     HUE_FLOW = '4',
     THEATER_CHASE_MODE = '5',
     PILE_UP_MODE = '6',
-    RAINBOW_MODE = '7'
+    RAINBOW_MODE = '7',
+    TRAFFIC_MODE = '8'
 };
 
 bool debug = true;
@@ -176,6 +177,9 @@ void loop()
         break;
     case RAINBOW_MODE:
         led.modeRainbow();
+        break;
+    case TRAFFIC_MODE:
+        led.modeTraffic();
         break;
     default:
         Serial.println("[MODE] unknown");

--- a/periph_sw/nRF52_RGB_Strip/nRF52_RGB_Strip.ino
+++ b/periph_sw/nRF52_RGB_Strip/nRF52_RGB_Strip.ino
@@ -119,10 +119,10 @@ void readUART(uint8_t *const p_ledMode)
                 Serial.println("[SETTINGS] request cfg, will send chunk#2");
                 ble.sendPacket(ble.Services::DEV_SETTINGS,
                                String("2;")
-                               + settings.sig_front_lower + ";"
-                               + settings.sig_front_upper + ";"
-                               + settings.sig_rear_lower + ";"
-                               + settings.sig_rear_upper);
+                               + settings.traffic_front_lower + ";"
+                               + settings.traffic_front_upper + ";"
+                               + settings.traffic_rear_lower + ";"
+                               + settings.traffic_rear_upper);
                 break;
             case '2':
                 Serial.println("[SETTINGS] request cfg done.");
@@ -133,25 +133,25 @@ void readUART(uint8_t *const p_ledMode)
             case 'A':
                 Serial.println("[SETTINGS] getting cfg chunk#1 ask for chunk#2");
                 settings.num_pixels = packetPayload[1];
-                Serial.println(String(settings.num_pixels));
+                //Serial.println(String(settings.num_pixels));
                 settings.device_name = "";
                 for (int i = 3; i < len_payload; i++)
                 {
                     settings.device_name += char(packetPayload[i]);
                 }
-                Serial.println(settings.device_name);
+                //Serial.println(settings.device_name);
                 ble.sendPacket(ble.Services::DEV_SETTINGS, "B");
                 break;
             case 'B':
                 Serial.println("[SETTINGS] getting chunk#2");
-                settings.sig_front_lower = packetPayload[1];
-                Serial.println(String(settings.sig_front_lower));
-                settings.sig_front_upper = packetPayload[3];
-                Serial.println(String(settings.sig_front_upper));
-                settings.sig_rear_lower = packetPayload[5];
-                Serial.println(String(settings.sig_rear_lower));
-                settings.sig_rear_upper = packetPayload[7];
-                Serial.println(String(settings.sig_rear_upper));
+                settings.traffic_front_lower = packetPayload[1];
+                //Serial.println(String(settings.traffic_front_lower));
+                settings.traffic_front_upper = packetPayload[3];
+                //Serial.println(String(settings.traffic_front_upper));
+                settings.traffic_rear_lower = packetPayload[5];
+                //Serial.println(String(settings.traffic_rear_lower));
+                settings.traffic_rear_upper = packetPayload[7];
+                //Serial.println(String(settings.traffic_rear_upper));
                 // Save all settings once done.
                 eeprom.save(settings);
                 break;

--- a/periph_sw/nRF52_RGB_Strip/nRF52_RGB_Strip.ino
+++ b/periph_sw/nRF52_RGB_Strip/nRF52_RGB_Strip.ino
@@ -114,15 +114,25 @@ void readUART(uint8_t *const p_ledMode)
         if(len_payload > 0)
         {
             settings.num_pixels = packetPayload[0];
+            settings.sig_front_lower = packetPayload[2];
+            settings.sig_front_upper = packetPayload[4];
+            settings.sig_rear_lower = packetPayload[6];
+            settings.sig_rear_upper = packetPayload[8];
             settings.device_name = "";
-            for (int i = 2; i < len_payload; i++)
+            for (int i = 10; i < len_payload; i++)
             {
                 settings.device_name += char(packetPayload[i]);
             }
             Serial.println(settings.device_name);
             eeprom.save(settings);
         }
-        ble.sendPacket(ble.Services::DEV_SETTINGS, String(settings.num_pixels) + ";" + settings.device_name);
+        ble.sendPacket(ble.Services::DEV_SETTINGS,
+                       String(settings.num_pixels) + ";"
+                       + settings.sig_front_lower + ";"
+                       + settings.sig_front_upper + ";"
+                       + settings.sig_rear_lower + ";"
+                       + settings.sig_rear_upper + ";"
+                       + settings.device_name);
         break;
     default:
         Serial.println("[SERVICE] unknown");

--- a/periph_sw/nRF52_RGB_Strip/nRF52_RGB_Strip.ino
+++ b/periph_sw/nRF52_RGB_Strip/nRF52_RGB_Strip.ino
@@ -4,13 +4,9 @@
 #include "ble_handler.h"
 #include "eeprom_handler.h"
 
-/* Need to undefine min and max in order to compile <String>. */
-#undef max
-#undef min
 #include <String>
 
 #define READ_BUFSIZE (40) /* Size of the read buffer for incoming packets */
-
 
 enum LEDMode
 {
@@ -32,10 +28,10 @@ const int pinData = 2;
 long local_time_offset = 0;
 unsigned long server_clock_ms = 0;
 
-CtrlLED led(pinData, pinDebug);
 BLE_Handler ble;
 EEPROM_Handler eeprom;
 Settings settings;
+CtrlLED led(pinData, pinDebug, &settings);
 
 void setup()
 {
@@ -54,7 +50,7 @@ void setup()
     ble.startAdv();
 
     // Initialise the LED strip.
-    led.configure(settings.num_pixels);
+    led.configure();
 }
 
 void readUART(uint8_t *const p_ledMode)

--- a/phone_app/src/app/app.module.ts
+++ b/phone_app/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { MyApp } from './app.component';
 import { TabsPage } from '../pages/tabs/tabs';
 import { HomePage } from '../pages/home/home';
 import { PeripheralsPage } from '../pages/peripherals/peripherals';
+import { SingleUserPage } from '../pages/single_user/single_user';
 import { PopoverSettings } from '../pages/peripherals/popover-settings';
 import { BleServiceProvider } from '../providers/ble-service';
 
@@ -21,6 +22,7 @@ import { BleServiceProvider } from '../providers/ble-service';
     TabsPage,
     HomePage,
     PeripheralsPage,
+    SingleUserPage,
     PopoverSettings
   ],
   imports: [
@@ -33,6 +35,7 @@ import { BleServiceProvider } from '../providers/ble-service';
     TabsPage,
     HomePage,
     PeripheralsPage,
+    SingleUserPage,
     PopoverSettings
   ],
   providers: [

--- a/phone_app/src/classes/color.ts
+++ b/phone_app/src/classes/color.ts
@@ -1,0 +1,48 @@
+
+export class Color {
+    r = 0;
+    g = 0;
+    b = 0;
+    brightness = 100;
+    saturation = 100;
+    r_final = 0;
+    g_final = 0;
+    b_final = 0;
+
+    constructor(r, g, b) {
+        this.setRGB(r, g, b);
+    }
+
+    setRGB(r, g, b) {
+        this.r = r;
+        this.g = g;
+        this.b = b;
+        this.computeFinalRGB();
+    }
+
+    setBrightness(brightness) {
+        this.brightness = brightness;
+        this.computeFinalRGB();
+    }
+
+    computeFinalRGB() {
+        var r = this.r;
+        var g = this.g;
+        var b = this.b;
+        var max_val = Math.max(r, g, b);
+        r = r + (max_val - r) * (100 - this.saturation) / 100.0;
+        g = g + (max_val - g) * (100 - this.saturation) / 100.0;
+        b = b + (max_val - b) * (100 - this.saturation) / 100.0;
+        r = r * this.brightness / 100.0;
+        g = g * this.brightness / 100.0;
+        b = b * this.brightness / 100.0;
+        this.r_final = Math.round(r);
+        this.g_final = Math.round(g);
+        this.b_final = Math.round(b);
+        console.log("changeColor", this.r_final, this.g_final, this.b_final);
+    }
+
+    getRGBstring() {
+        return "rgb(" + String(this.r_final) + "," + String(this.g_final) + "," + String(this.b_final) + ")";
+    }
+}

--- a/phone_app/src/classes/mode.ts
+++ b/phone_app/src/classes/mode.ts
@@ -9,7 +9,7 @@ export class Mode {
         "THEATER_CHASE": { val: '5', color_picker: true, tempo_picker: true },
         "PILE_UP": { val: '6', color_picker: true, tempo_picker: true },
         "RAINBOW_MODE": { val: '7', color_picker: false, tempo_picker: true },
-        "SIGNALISATION_MODE": { val: '8', color_picker: false, tempo_picker: false }
+        "TRAFFIC_MODE": { val: '8', color_picker: false, tempo_picker: false }
     };
 
     constructor() {}

--- a/phone_app/src/classes/mode.ts
+++ b/phone_app/src/classes/mode.ts
@@ -1,0 +1,16 @@
+
+export class Mode {
+    public static list = {
+        "OFF": { val: '0', color_picker: false, tempo_picker: false },
+        "ON": { val: '1', color_picker: true, tempo_picker: false },
+        "FLASH": { val: '2', color_picker: true, tempo_picker: true },
+        "PULSE": { val: '3', color_picker: true, tempo_picker: true },
+        "HUE_FLOW": { val: '4', color_picker: false, tempo_picker: true },
+        "THEATER_CHASE": { val: '5', color_picker: true, tempo_picker: true },
+        "PILE_UP": { val: '6', color_picker: true, tempo_picker: true },
+        "RAINBOW_MODE": { val: '7', color_picker: false, tempo_picker: true },
+        "SIGNALISATION_MODE": { val: '8', color_picker: false, tempo_picker: false }
+    };
+
+    constructor() {}
+};

--- a/phone_app/src/classes/periph.ts
+++ b/phone_app/src/classes/periph.ts
@@ -11,10 +11,10 @@ export class Periph {
     color_b: number = 0;
     color_rgb: string = "";
     tempo: string = "";
-    sig_front_lower: number = 0;
-    sig_front_upper: number = 0;
-    sig_rear_lower: number = 0;
-    sig_rear_upper: number = 0;
+    traffic_front_lower: number = 0;
+    traffic_front_upper: number = 0;
+    traffic_rear_lower: number = 0;
+    traffic_rear_upper: number = 0;
 
     constructor(id, name) {
         this.id = id;

--- a/phone_app/src/classes/periph.ts
+++ b/phone_app/src/classes/periph.ts
@@ -11,6 +11,10 @@ export class Periph {
     color_b: number = 0;
     color_rgb: string = "";
     tempo: string = "";
+    sig_front_lower: number = 0;
+    sig_front_upper: number = 0;
+    sig_rear_lower: number = 0;
+    sig_rear_upper: number = 0;
 
     constructor(id, name) {
         this.id = id;

--- a/phone_app/src/pages/home/home.html
+++ b/phone_app/src/pages/home/home.html
@@ -60,6 +60,12 @@
                     <ion-icon name="md-color-palette"></ion-icon>Rainbow
                 </button>
             </ion-col>
+            <ion-col>
+                <button ion-button block icon-left color="light" (click)="modeChanged('TRAFFIC_MODE')" [ngStyle]="{'border': isModeSelected('TRAFFIC_MODE')}"
+                    [disabled]="isAuto">
+                    <ion-icon name="md-car"></ion-icon>Traffic
+                </button>
+            </ion-col>
         </ion-row>
     </ion-grid>
     <ion-grid>

--- a/phone_app/src/pages/home/home.ts
+++ b/phone_app/src/pages/home/home.ts
@@ -229,7 +229,7 @@ export class HomePage {
     requestSettings(periph: Periph) {
         console.log("requestSettings");
         // check again that only one device is connected
-        this.bleService.writeBLE(periph, BLE_SERVICES.DEV_SETTINGS, "")
+        this.bleService.writeBLE(periph, BLE_SERVICES.DEV_SETTINGS, "?")
             .then(data => {
                 console.log("success", data);
             })

--- a/phone_app/src/pages/home/home.ts
+++ b/phone_app/src/pages/home/home.ts
@@ -4,18 +4,7 @@ import { NavController } from 'ionic-angular';
 import { BleServiceProvider, BLE_SERVICES } from '../../providers/ble-service';
 import { Periph } from '../../classes/periph';
 import { Color } from '../../classes/color';
-
-var LED_MODE =
-    {
-        "OFF": { val: '0', color_picker: false, tempo_picker: false },
-        "ON": { val: '1', color_picker: true, tempo_picker: false },
-        "FLASH": { val: '2', color_picker: true, tempo_picker: true },
-        "PULSE": { val: '3', color_picker: true, tempo_picker: true },
-        "HUE_FLOW": { val: '4', color_picker: false, tempo_picker: true },
-        "THEATER_CHASE": { val: '5', color_picker: true, tempo_picker: true },
-        "PILE_UP": { val: '6', color_picker: true, tempo_picker: true },
-        "RAINBOW_MODE": { val: '7', color_picker: false, tempo_picker: true }
-    };
+import { Mode } from '../../classes/mode';
 
 @Component({
     selector: 'page-home',
@@ -75,11 +64,11 @@ export class HomePage {
     }
 
     showColorPicker() {
-        return LED_MODE[this.mode].color_picker;
+        return Mode.list[this.mode].color_picker;
     }
 
     showTempo() {
-        return LED_MODE[this.mode].tempo_picker;
+        return Mode.list[this.mode].tempo_picker;
     }
 
     scanToggle() {
@@ -143,7 +132,7 @@ export class HomePage {
         clearTimeout(this.intervalAutomode_ID);
         if (this.isAuto) {
             this.intervalAutomode_ID = setTimeout(() => {
-                var modes = Object.keys(LED_MODE);
+                var modes = Object.keys(Mode.list);
                 var idx_color = Math.round(Math.random() * (this.colorsPresetsList.length - 1));
                 this.setColor(this.colorsPresetsList[idx_color]);
                 var idx = 2 + Math.round(Math.random() * (modes.length - 1 - 2));
@@ -272,7 +261,7 @@ export class HomePage {
     }
 
     private changeMode(periph) {
-        this.bleService.writeBLE(periph, BLE_SERVICES.MODE, LED_MODE[this.mode].val)
+        this.bleService.writeBLE(periph, BLE_SERVICES.MODE, Mode.list[this.mode].val)
             .then(data => {
                 console.log("success", data);
             })

--- a/phone_app/src/pages/home/home.ts
+++ b/phone_app/src/pages/home/home.ts
@@ -3,6 +3,7 @@ import { NavController } from 'ionic-angular';
 
 import { BleServiceProvider, BLE_SERVICES } from '../../providers/ble-service';
 import { Periph } from '../../classes/periph';
+import { Color } from '../../classes/color';
 
 var LED_MODE =
     {
@@ -15,55 +16,6 @@ var LED_MODE =
         "PILE_UP": { val: '6', color_picker: true, tempo_picker: true },
         "RAINBOW_MODE": { val: '7', color_picker: false, tempo_picker: true }
     };
-
-
-class Color {
-    r = 0;
-    g = 0;
-    b = 0;
-    brightness = 100;
-    saturation = 100;
-    r_final = 0;
-    g_final = 0;
-    b_final = 0;
-
-    constructor(r, g, b) {
-        this.setRGB(r, g, b);
-    }
-
-    setRGB(r, g, b) {
-        this.r = r;
-        this.g = g;
-        this.b = b;
-        this.computeFinalRGB();
-    }
-
-    setBrightness(brightness) {
-        this.brightness = brightness;
-        this.computeFinalRGB();
-    }
-
-    computeFinalRGB() {
-        var r = this.r;
-        var g = this.g;
-        var b = this.b;
-        var max_val = Math.max(r, g, b);
-        r = r + (max_val - r) * (100 - this.saturation) / 100.0;
-        g = g + (max_val - g) * (100 - this.saturation) / 100.0;
-        b = b + (max_val - b) * (100 - this.saturation) / 100.0;
-        r = r * this.brightness / 100.0;
-        g = g * this.brightness / 100.0;
-        b = b * this.brightness / 100.0;
-        this.r_final = Math.round(r);
-        this.g_final = Math.round(g);
-        this.b_final = Math.round(b);
-        console.log("changeColor", this.r_final, this.g_final, this.b_final);
-    }
-
-    getRGBstring() {
-        return "rgb(" + String(this.r_final) + "," + String(this.g_final) + "," + String(this.b_final) + ")";
-    }
-}
 
 @Component({
     selector: 'page-home',

--- a/phone_app/src/pages/peripherals/peripherals.scss
+++ b/phone_app/src/pages/peripherals/peripherals.scss
@@ -1,2 +1,8 @@
 page-peripherals {
+    #range-sig-front{
+        color: yellow;
+    }
+    #range-sig-rear{
+        color: red;
+    }
 }

--- a/phone_app/src/pages/peripherals/peripherals.ts
+++ b/phone_app/src/pages/peripherals/peripherals.ts
@@ -54,9 +54,8 @@ export class PeripheralsPage {
 
     setSettings(periph: Periph) {
         console.log("changeSettings");
-        // check again that only one device is connected
-        this.bleService.writeBLE(periph, BLE_SERVICES.DEV_SETTINGS,
-            String.fromCharCode(periph.num_pixels) + ";" + periph.name)
+        // todo: ? check again that only one device is connected
+        this.bleService.writeBLE(periph, BLE_SERVICES.DEV_SETTINGS, String("="))
             .then(data => {
                 console.log("success", data);
             })

--- a/phone_app/src/pages/peripherals/popover-settings.html
+++ b/phone_app/src/pages/peripherals/popover-settings.html
@@ -9,6 +9,21 @@
         <ion-label stacked>Number of Pixels</ion-label>
         <ion-input type="number" [(ngModel)]="periph.num_pixels"></ion-input>
     </ion-item>
+    <ion-card>
+        <ion-card-header>
+            Traffic
+        </ion-card-header>
+        Front
+        <ion-range id="range-sig-front" dualKnobs="true" min="{{ signalisationBoundaries.min }}" max="{{ signalisationBoundaries.max }}" step="1" pin="true" debounce="500" [(ngModel)]="signalisationValues.front" >
+            <ion-icon range-left name="md-arrow-dropright"></ion-icon>
+            <ion-icon range-right name="md-arrow-dropleft"></ion-icon>
+        </ion-range>
+        Rear
+        <ion-range id="range-sig-rear" dualKnobs="true" min="{{ signalisationBoundaries.min }}" max="{{ signalisationBoundaries.max }}" step="1" pin="true" debounce="500" [(ngModel)]="signalisationValues.rear">
+            <ion-icon range-left name="md-arrow-dropright"></ion-icon>
+            <ion-icon range-right name="md-arrow-dropleft"></ion-icon>
+        </ion-range>
+    </ion-card>
     <ion-grid>
         <ion-row>
             <ion-col>

--- a/phone_app/src/pages/peripherals/popover-settings.html
+++ b/phone_app/src/pages/peripherals/popover-settings.html
@@ -10,18 +10,15 @@
         <ion-input type="number" [(ngModel)]="periph.num_pixels"></ion-input>
     </ion-item>
     <ion-card>
-        <ion-card-header>
-            Traffic
-        </ion-card-header>
-        Front
+        TrafficMode: Front
         <ion-range id="range-sig-front" dualKnobs="true" min="{{ signalisationBoundaries.min }}" max="{{ signalisationBoundaries.max }}" step="1" pin="true" debounce="500" [(ngModel)]="signalisationValues.front" >
-            <ion-icon range-left name="md-arrow-dropright"></ion-icon>
-            <ion-icon range-right name="md-arrow-dropleft"></ion-icon>
+            <ion-label range-left>{{ signalisationBoundaries.min }}</ion-label>
+            <ion-label range-right>{{ signalisationBoundaries.max }}</ion-label>
         </ion-range>
-        Rear
+        TrafficMode: Rear
         <ion-range id="range-sig-rear" dualKnobs="true" min="{{ signalisationBoundaries.min }}" max="{{ signalisationBoundaries.max }}" step="1" pin="true" debounce="500" [(ngModel)]="signalisationValues.rear">
-            <ion-icon range-left name="md-arrow-dropright"></ion-icon>
-            <ion-icon range-right name="md-arrow-dropleft"></ion-icon>
+            <ion-label range-left>{{ signalisationBoundaries.min }}</ion-label>
+            <ion-label range-right>{{ signalisationBoundaries.max }}</ion-label>
         </ion-range>
     </ion-card>
     <ion-grid>

--- a/phone_app/src/pages/peripherals/popover-settings.ts
+++ b/phone_app/src/pages/peripherals/popover-settings.ts
@@ -4,14 +4,33 @@ import {NavParams} from 'ionic-angular';
 import { Periph } from '../../classes/periph';
 
 @Component({
+    selector: 'page-peripheral',
     templateUrl: 'popover-settings.html'
 })
 
 export class PopoverSettings {
     periph: Periph;
+    
+    signalisationBoundaries = { min: 0, max: 1 };
+    signalisationValues = {
+        front: { lower: 0, upper: 0 },
+        rear: { lower: 0, upper: 0}
+    };
 
     constructor(public viewCtrl: ViewController, public params: NavParams) { 
         this.periph = this.params.get('periph');
+        this.signalisationValues = {
+            front: {
+                lower: this.periph.sig_front_lower,
+                upper: this.periph.sig_front_upper
+            },
+            rear: {
+                lower: this.periph.sig_rear_lower,
+                upper: this.periph.sig_rear_upper
+            }
+        };
+
+        this.signalisationBoundaries.max = this.periph.num_pixels;
     }
 
     close() {
@@ -19,6 +38,10 @@ export class PopoverSettings {
     }
 
     save() {
+        this.periph.sig_front_lower = this.signalisationValues.front.lower;
+        this.periph.sig_front_upper = this.signalisationValues.front.upper;
+        this.periph.sig_rear_lower = this.signalisationValues.rear.lower;
+        this.periph.sig_rear_upper = this.signalisationValues.rear.upper;
         this.viewCtrl.dismiss(this.periph);
     }
 }

--- a/phone_app/src/pages/peripherals/popover-settings.ts
+++ b/phone_app/src/pages/peripherals/popover-settings.ts
@@ -11,22 +11,22 @@ import { Periph } from '../../classes/periph';
 export class PopoverSettings {
     periph: Periph;
     
-    signalisationBoundaries = { min: 0, max: 1 };
+    signalisationBoundaries = { min: 1, max: 1 };
     signalisationValues = {
-        front: { lower: 0, upper: 0 },
-        rear: { lower: 0, upper: 0}
+        front: { lower: this.signalisationBoundaries.min, upper: this.signalisationBoundaries.min },
+        rear: { lower: this.signalisationBoundaries.min, upper: this.signalisationBoundaries.min}
     };
 
     constructor(public viewCtrl: ViewController, public params: NavParams) { 
         this.periph = this.params.get('periph');
         this.signalisationValues = {
             front: {
-                lower: this.periph.sig_front_lower,
-                upper: this.periph.sig_front_upper
+                lower: this.periph.traffic_front_lower,
+                upper: this.periph.traffic_front_upper
             },
             rear: {
-                lower: this.periph.sig_rear_lower,
-                upper: this.periph.sig_rear_upper
+                lower: this.periph.traffic_rear_lower,
+                upper: this.periph.traffic_rear_upper
             }
         };
 
@@ -38,10 +38,10 @@ export class PopoverSettings {
     }
 
     save() {
-        this.periph.sig_front_lower = this.signalisationValues.front.lower;
-        this.periph.sig_front_upper = this.signalisationValues.front.upper;
-        this.periph.sig_rear_lower = this.signalisationValues.rear.lower;
-        this.periph.sig_rear_upper = this.signalisationValues.rear.upper;
+        this.periph.traffic_front_lower = this.signalisationValues.front.lower;
+        this.periph.traffic_front_upper = this.signalisationValues.front.upper;
+        this.periph.traffic_rear_lower = this.signalisationValues.rear.lower;
+        this.periph.traffic_rear_upper = this.signalisationValues.rear.upper;
         this.viewCtrl.dismiss(this.periph);
     }
 }

--- a/phone_app/src/pages/single_user/single_user.html
+++ b/phone_app/src/pages/single_user/single_user.html
@@ -1,0 +1,11 @@
+<ion-header>
+    <ion-navbar>
+        <ion-title>
+            Single user mode
+        </ion-title>
+    </ion-navbar>
+</ion-header>
+
+<ion-content padding>
+
+</ion-content>

--- a/phone_app/src/pages/single_user/single_user.scss
+++ b/phone_app/src/pages/single_user/single_user.scss
@@ -1,0 +1,3 @@
+single_user {
+    
+}

--- a/phone_app/src/pages/single_user/single_user.ts
+++ b/phone_app/src/pages/single_user/single_user.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { NavController } from 'ionic-angular';
+
+@Component({
+    templateUrl: 'single_user.html'
+})
+export class SingleUserPage {
+
+    constructor(public navCtrl: NavController) {
+
+    }
+
+}

--- a/phone_app/src/pages/tabs/tabs.html
+++ b/phone_app/src/pages/tabs/tabs.html
@@ -1,4 +1,5 @@
 <ion-tabs>
   <ion-tab [root]="tab1Root" tabIcon="home"></ion-tab>
+  <ion-tab [root]="tab3Root" tabIcon="person"></ion-tab>
   <ion-tab [root]="tab2Root" tabIcon="bicycle" tabBadge=" {{ listConnectedPeriphs().length }}" tabBadgeStyle="primary"></ion-tab>
 </ion-tabs>

--- a/phone_app/src/pages/tabs/tabs.ts
+++ b/phone_app/src/pages/tabs/tabs.ts
@@ -4,6 +4,7 @@ import { BleServiceProvider } from '../../providers/ble-service';
 
 import { HomePage } from '../home/home';
 import { PeripheralsPage } from '../peripherals/peripherals';
+import { SingleUserPage } from '../single_user/single_user';
 
 @Component({
   templateUrl: 'tabs.html'
@@ -12,6 +13,7 @@ export class TabsPage {
 
   tab1Root = HomePage;
   tab2Root = PeripheralsPage;
+  tab3Root = SingleUserPage;
 
   constructor(private bleService: BleServiceProvider) {
 

--- a/phone_app/src/providers/ble-service.ts
+++ b/phone_app/src/providers/ble-service.ts
@@ -219,15 +219,78 @@ export class BleServiceProvider {
                 }
                 else if (this.isService(string_received, BLE_SERVICES.DEV_SETTINGS)) {
                     var settings = payload.split(";");
-                    periph.num_pixels = parseInt(settings[0]);
-                    periph.name = String(settings[1]);
+                    switch (settings[0])
+                    {
+                        case "1":
+                            periph.num_pixels = parseInt(settings[1]);
+                            periph.name = String(settings[2]);
+                            console.log("[DEV_SETTINGS] Received param. "
+                                        + "num_pixel (" + String(periph.num_pixels) +  "), "
+                                        + "name (" + periph.name + ").");
+                            this.writeBLE(periph, BLE_SERVICES.DEV_SETTINGS, settings[0])
+                                .then(data => {
+                                    console.log("[DEV_SETTINGS] " + settings[0] + " success.", data);
+                                })
+                                .catch(err => {
+                                    console.log("[DEV_SETTINGS] " + settings[0] + " failed.", data);
+                                })
+                            break;
+                        case "2":
+                            periph.sig_front_lower = parseInt(settings[1]);
+                            periph.sig_front_upper = parseInt(settings[2]);
+                            periph.sig_rear_lower = parseInt(settings[3]);
+                            periph.sig_rear_upper = parseInt(settings[4]);
+                            console.log("[DEV_SETTINGS] Received param: traffic param."
+                                        + "sig_front_lower (" + String(periph.sig_front_lower) + "), "
+                                        + "sig_front_upper (" + String(periph.sig_front_upper) + "), "
+                                        + "sig_rear_lower (" + String(periph.sig_rear_lower) + "), "
+                                        + "sig_rear_upper (" + String(periph.sig_rear_upper) + ").");
+                            this.writeBLE(periph, BLE_SERVICES.DEV_SETTINGS, settings[0])
+                                .then(data => {
+                                    console.log("[DEV_SETTINGS] " + settings[0] + " success.", data);
+                                })
+                                .catch(err => {
+                                    console.log("[DEV_SETTINGS] " + settings[0] + " failed.", data);
+                                })
+                            break;
+                            case "A":
+                                console.log("[DEV_SETTINGS] Sending param: num_pixel, name.");
+                                this.writeBLE(periph, BLE_SERVICES.DEV_SETTINGS,
+                                            settings[0] + String.fromCharCode(periph.num_pixels) + ";"
+                                            + periph.name)
+                                    .then(data => {
+                                        console.log("[DEV_SETTINGS] " + settings[0] + " success.", data);
+                                    })
+                                    .catch(err => {
+                                        console.log("[DEV_SETTINGS] " + settings[0] + " failed.", data);
+                                    })
+                                    break;
+                        case "B":
+                            console.log("[DEV_SETTINGS] Sending param: traffic indices.");
+                            this.writeBLE(periph, BLE_SERVICES.DEV_SETTINGS,
+                                        settings[0]
+                                        + String.fromCharCode(periph.sig_front_lower) + ";"
+                                        + String.fromCharCode(periph.sig_front_upper) + ";"
+                                        + String.fromCharCode(periph.sig_rear_lower) + ";"
+                                        + String.fromCharCode(periph.sig_rear_upper))
+                                .then(data => {
+                                    console.log("[DEV_SETTINGS] " + settings[0] + " success.", data);
+                                })
+                                .catch(err => {
+                                    console.log("[DEV_SETTINGS] " + settings[0] + " failed.", data);
+                                })
+                                break;
+                        default:
+                            console.log("[DEV_SETTINGS] Received " + settings[0] + ", do nothing.");
+                            break;
+                    }
                 }
                 else {
                     console.log("unknown service", string_received);
                 }
             }
             else {
-                console.log("non supported message", string_received);
+                console.log("non supported message (note: only 20 Bytes can be sent over BLE.)", string_received);
             }
 
         });

--- a/phone_app/src/providers/ble-service.ts
+++ b/phone_app/src/providers/ble-service.ts
@@ -6,6 +6,7 @@ import { Platform } from 'ionic-angular';
 import { LocationAccuracy } from '@ionic-native/location-accuracy';
 
 import { Periph } from '../classes/periph';
+import { Mode } from '../classes/mode';
 
 const SERVICE_UUID_UART = '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
 const CHARAC_UUID_UART_RX = '6e400003-b5a3-f393-e0a9-e50e24dcca9e';
@@ -21,17 +22,6 @@ export const BLE_SERVICES = {
     TEMPO: 'T',
     DEV_SETTINGS: 'D'
 }
-
-var MODES =
-    [
-        "OFF",
-        "ON",
-        "FLASH",
-        "PULSE",
-        "HUE_FLOW",
-        "THEATER",
-        "PILE_UP"
-    ];
 
 @Injectable()
 export class BleServiceProvider {
@@ -215,7 +205,7 @@ export class BleServiceProvider {
                     periph.globalTimerModulusMs = payload;
                 }
                 else if (this.isService(string_received, BLE_SERVICES.MODE)) {
-                    periph.mode = MODES[Number(payload)];
+                    periph.mode = Mode.list[Number(payload)];
                 }
                 else if (this.isService(string_received, BLE_SERVICES.COLOR)) {
                     var colors = payload.split(",");

--- a/phone_app/src/providers/ble-service.ts
+++ b/phone_app/src/providers/ble-service.ts
@@ -236,15 +236,15 @@ export class BleServiceProvider {
                                 })
                             break;
                         case "2":
-                            periph.sig_front_lower = parseInt(settings[1]);
-                            periph.sig_front_upper = parseInt(settings[2]);
-                            periph.sig_rear_lower = parseInt(settings[3]);
-                            periph.sig_rear_upper = parseInt(settings[4]);
+                            periph.traffic_front_lower = parseInt(settings[1]);
+                            periph.traffic_front_upper = parseInt(settings[2]);
+                            periph.traffic_rear_lower = parseInt(settings[3]);
+                            periph.traffic_rear_upper = parseInt(settings[4]);
                             console.log("[DEV_SETTINGS] Received param: traffic param."
-                                        + "sig_front_lower (" + String(periph.sig_front_lower) + "), "
-                                        + "sig_front_upper (" + String(periph.sig_front_upper) + "), "
-                                        + "sig_rear_lower (" + String(periph.sig_rear_lower) + "), "
-                                        + "sig_rear_upper (" + String(periph.sig_rear_upper) + ").");
+                                        + "traffic_front_lower (" + String(periph.traffic_front_lower) + "), "
+                                        + "traffic_front_upper (" + String(periph.traffic_front_upper) + "), "
+                                        + "traffic_rear_lower (" + String(periph.traffic_rear_lower) + "), "
+                                        + "traffic_rear_upper (" + String(periph.traffic_rear_upper) + ").");
                             this.writeBLE(periph, BLE_SERVICES.DEV_SETTINGS, settings[0])
                                 .then(data => {
                                     console.log("[DEV_SETTINGS] " + settings[0] + " success.", data);
@@ -269,10 +269,10 @@ export class BleServiceProvider {
                             console.log("[DEV_SETTINGS] Sending param: traffic indices.");
                             this.writeBLE(periph, BLE_SERVICES.DEV_SETTINGS,
                                         settings[0]
-                                        + String.fromCharCode(periph.sig_front_lower) + ";"
-                                        + String.fromCharCode(periph.sig_front_upper) + ";"
-                                        + String.fromCharCode(periph.sig_rear_lower) + ";"
-                                        + String.fromCharCode(periph.sig_rear_upper))
+                                        + String.fromCharCode(periph.traffic_front_lower) + ";"
+                                        + String.fromCharCode(periph.traffic_front_upper) + ";"
+                                        + String.fromCharCode(periph.traffic_rear_lower) + ";"
+                                        + String.fromCharCode(periph.traffic_rear_upper))
                                 .then(data => {
                                     console.log("[DEV_SETTINGS] " + settings[0] + " success.", data);
                                 })


### PR DESCRIPTION
Fixing issues: #1 and #20 

Implemented as following:
- front and rear light segments - each as (lower, upper) pairs [1; num_pixels] - are stored with Nffs as Peripheral settings (e.g. "traffic_front_lower")
- default values are provided by the settings manager
- colors are front = rgb(255, 255, 255), rear = rgb(255, 0, 0)
- settings are configurable via the Central in the Popover, inputs are ranges [1; num_pixels]
- if front/rear overlap, rear overwrites the front as per the sequential flow implemented
- the LED library directly reads the settings (pointer passed over during init.) allowing one to change settings on the fly without having to reboot the Peripheral
- a new TrafficMode has been introduced to the main tab

note: the lightninh direction is part of the issue #19 